### PR TITLE
hotfix: Fix OAuth login session issue and enable Spring Session with Redis

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,7 @@ dependencies {
     implementation group: 'com.alphacephei', name: 'vosk', version: '0.3.45'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'com.alphacephei:vosk:0.3.38'
+    implementation 'org.springframework.session:spring-session-data-redis'
 }
 
 tasks.named('test') {

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -29,6 +29,13 @@ spring:
             user-info-uri: https://api.github.com/user
             user-name-attribute: id
 
+  session:
+    store-type: redis
+    redis:
+      flush-mode: on-save
+      namespace: skillboost:session
+
+
 jwt:
   secret-key: ${JWT_SECRET_KEY}
   expiration-ms: 86400000


### PR DESCRIPTION
### Hotfix Summary
- Fixed OAuth2 login issue occurring with multiple replicas.
- Enabled Redis-backed Spring Session to prevent session/state mismatch.
- Updated `application-prod.yml` with `spring.session.store-type=redis`.
- Added `spring-session-data-redis` dependency to `build.gradle`.

### Effect
This resolves the login failure happening only in the production cluster with replicas=2.

### Merge Target
→ main